### PR TITLE
docker: entrypoint: replace su by runuser

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -23,6 +23,4 @@ useradd \
 chown -R docker:docker /home/docker
 
 # Execute the command as docker
-COMMAND=$(which ${1})
-shift
-exec su docker --shell ${COMMAND} -- $@
+exec runuser -u docker -- "$@"


### PR DESCRIPTION
Using su(1) with the --shell hack has one drawback, the SHELL variable is set to the specified shell.

In our use case, we have SHELL=/usr/bin/make, which is not good for the applications using it.

This commit replaces su(1) by runuser(1) as suggested by the su man page:

> su(1) is  mostly  designed for unprivileged users, the recommended
> solution for privileged users is to use runuser(1).