### PR TITLE
container: add build policy

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+env:
+  PY_COLORS: "1"
+
 jobs:
   pytest:
     runs-on: ubuntu-latest

--- a/core/container/docker.mk
+++ b/core/container/docker.mk
@@ -22,6 +22,9 @@ endif
 # Include the common container makefile.
 include ${OPENBAR_DIR}/includes/container.mk
 
+# The "docker exists" command line.
+CONTAINER_EXISTS := docker inspect ${CONTAINER_TAG} >/dev/null 2>&1
+
 # The "docker build" command line.
 CONTAINER_BUILD := docker build
 CONTAINER_BUILD += ${CONTAINER_BUILD_ARGS}
@@ -54,3 +57,6 @@ CONTAINER_RUN += ${OB_DOCKER_RUN_EXTRA_ARGS}
 
 # Use the previously build image.
 CONTAINER_RUN += ${CONTAINER_TAG}
+
+# Forward to the type layer.
+include ${OPENBAR_DIR}/includes/container_forward.mk

--- a/core/container/podman.mk
+++ b/core/container/podman.mk
@@ -22,6 +22,9 @@ endif
 # Include the common container makefile.
 include ${OPENBAR_DIR}/includes/container.mk
 
+# The "podman exists" command line.
+CONTAINER_EXISTS := podman image exists ${CONTAINER_TAG}
+
 # The "podman build" command line.
 CONTAINER_BUILD := podman build
 CONTAINER_BUILD += ${CONTAINER_BUILD_ARGS}
@@ -51,3 +54,6 @@ CONTAINER_RUN += ${OB_PODMAN_RUN_EXTRA_ARGS}
 
 # Use the previously build image.
 CONTAINER_RUN += ${CONTAINER_TAG}
+
+# Forward to the type layer.
+include ${OPENBAR_DIR}/includes/container_forward.mk

--- a/core/main.mk
+++ b/core/main.mk
@@ -13,6 +13,11 @@ OPENBAR_DIR := $(realpath $(dir $(lastword ${MAKEFILE_LIST}))/..)
 # The base directory where the root makefile is located.
 OB_ROOT_DIR := ${CURDIR}
 
+# Support the B= option in command line.
+ifeq ($(origin B),command line)
+  OB_CONTAINER_FORCE_BUILD := $(B)
+endif
+
 # Support the O= option in command line.
 ifeq ($(origin O),command line)
   OB_BUILD_DIR := $(abspath ${O})
@@ -32,10 +37,10 @@ OB_VERBOSE ?= 0
 # The container engine to be used.
 OB_CONTAINER_ENGINE ?= podman
 
-# Add all command line variables except O and V to the export list.
+# Add all command line variables except B, O and V to the export list.
 CLI_VARIABLES = $(foreach variable,${.VARIABLES},$(if $(filter command line,$(origin ${variable})),${variable}))
 
-override OB_EXPORT += $(filter-out O V,${CLI_VARIABLES})
+override OB_EXPORT += $(filter-out B O V,${CLI_VARIABLES})
 
 # All the required variables have been set.
 include ${OPENBAR_DIR}/includes/verify-environment.mk
@@ -147,3 +152,5 @@ endif
 	@echo '  make V=0-1 [targets] 0 => quiet build (default)'
 	@echo '                       1 => verbose build'
 	@echo '  make O=dir [targets] Use the specified build directory (default: build)'
+	@echo '  make B=0-1 [targets] 0 => force container not to be built'
+	@echo '                       1 => force container to be built'

--- a/includes/container.mk
+++ b/includes/container.mk
@@ -15,6 +15,7 @@ OB_CONTAINER          ?= default
 OB_CONTAINER_FILENAME ?= Dockerfile
 OB_CONTAINER_CONTEXT  ?= ${OB_CONTAINER_DIR}/${OB_CONTAINER}
 OB_CONTAINER_FILE     ?= ${OB_CONTAINER_CONTEXT}/${OB_CONTAINER_FILENAME}
+OB_CONTAINER_POLICY   ?= missing
 
 # The generated container variables.
 CONTAINER_PROJECT     := $(call container-sanitize,$(notdir ${OB_ROOT_DIR}))
@@ -109,21 +110,3 @@ CONTAINER_RUN_ARGS += ${CONTAINER_ENV_ARGS}
 
 # Add optional extra arguments.
 CONTAINER_RUN_ARGS += ${OB_CONTAINER_RUN_EXTRA_ARGS}
-
-# All targets are forwarded to the next layer inside the container.
-${OB_ALL_TARGETS}: .forward
-
-ifeq (${OB_TYPE},simple)
-  NEXT_LAYER := type/simple.mk
-else
-  NEXT_LAYER := type/initenv.mk
-endif
-
-.PHONY: .forward
-.forward: .container-build | ${CONTAINER_VOLUME_HOSTDIRS}
-	${CONTAINER_RUN} $(call submake_noenv,${NEXT_LAYER})
-
-.PHONY: .container-build
-.container-build:
-	@echo "Building ${OB_CONTAINER_ENGINE} image '${CONTAINER_TAG}'"
-	${QUIET} ${CONTAINER_BUILD}

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -44,13 +44,13 @@ def test_defconfig(create_project):
 def test_all(create_project):
     project = create_project(defconfig="main_defconfig")
     stdout = project.make("all")
-    assert stdout[1:] == ["Foo", "Bar"]
+    assert stdout[-2:] == ["Foo", "Bar"]
     stdout = project.make()
-    assert stdout[1:] == ["Foo", "Bar"]
+    assert stdout[-2:] == ["Foo", "Bar"]
 
 
 def test_verbose(create_project):
-    project = create_project(defconfig="main_defconfig")
+    project = create_project(defconfig="main_defconfig", cli={"B": "1"})
 
     def expand_commands(commands):
         for maybe_command in commands:
@@ -125,7 +125,9 @@ def test_build_dir(create_project):
 
 
 def test_foreach(project_dirs, create_project):
-    project = create_project(defconfig_dir=project_dirs.tests_data_dir / "foreach")
+    project = create_project(
+        defconfig_dir=project_dirs.tests_data_dir / "foreach", cli={"B": "1"}
+    )
     stdout = project.make("foreach")
     for index, name in enumerate(["bar", "baz", "foo"]):
         assert stdout[3 * index + 0] == f"Build configured for {name}_defconfig"

--- a/tests/system_test.py
+++ b/tests/system_test.py
@@ -75,9 +75,7 @@ def test_project_fixture(create_project):
 
 
 def test_hello(create_project):
-    project = create_project(
-        defconfig="hello_defconfig",
-    )
+    project = create_project(defconfig="hello_defconfig", cli={"B": "1"})
 
     stdout = project.make()
 


### PR DESCRIPTION
From now on, container building occurs if:
 - The command line option B=1
 - OB_CONTAINER_FORCE_BUILD=1
 - OB_CONTAINER_POLICY=always
 - OB_CONTAINER_POLICY=missing and the container does not exists

And, container building does not occurs if:
 - The command line option B=0
 - OB_CONTAINER_FORCE_BUILD=0
 - OB_CONTAINER_POLICY=never
 - OB_CONTAINER_POLICY=missing and the container exists

The B= has priority over OB_CONTAINER_FORCE_BUILD= which has priority over OB_CONTAINER_POLICY=.

OB_CONTAINER_POLICY= is defaulted to "missing".